### PR TITLE
Make 'reload configuation from scope' option refresh views

### DIFF
--- a/src/glscopeclient/OscilloscopeWindow.cpp
+++ b/src/glscopeclient/OscilloscopeWindow.cpp
@@ -2903,6 +2903,13 @@ void OscilloscopeWindow::OnRefreshConfig()
 {
 	for(auto scope : m_scopes)
 		scope->FlushConfigCache();
+
+	//Redraw the timeline and all waveform areas to reflect anything changed from the scope
+	for(auto g : m_waveformGroups)
+		g->m_timeline.queue_draw();
+	for(auto a : m_waveformAreas)
+		a->queue_draw();
+
 }
 
 void OscilloscopeWindow::OnAutofitHorizontal()


### PR DESCRIPTION
Refresh views when scope configuration is reloaded. Both the timeline and waveforms are refreshed because changes could be in either.
