### PR TITLE
Windows/Vulkan build fix

### DIFF
--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -17,9 +17,11 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-glew"
   "${MINGW_PACKAGE_PREFIX}-ffts"
   "${MINGW_PACKAGE_PREFIX}-vulkan-loader"
-  "${MINGW_PACKAGE_PREFIX}-vulkan-header"
+  "${MINGW_PACKAGE_PREFIX}-vulkan-headers"
   "${MINGW_PACKAGE_PREFIX}-spirv-tools"
   "${MINGW_PACKAGE_PREFIX}-spirv-headers"
+  "${MINGW_PACKAGE_PREFIX}-opencl-headers"
+  "${MINGW_PACKAGE_PREFIX}-opencl-icd"
 )
 makedepends=(
   "${MINGW_PACKAGE_PREFIX}-cmake"


### PR DESCRIPTION
I've tested these changes on a clean MSYS2 install.

The source build now requires the [Vulkan SDK Core](https://vulkan.lunarg.com/sdk/home#windows) to be preinstalled before starting the MSYS2 environment. This ensures the `VK_SDK_PATH` and `VULKAN_SDK` environment variables are detected by the `include(FindVulkan)` step from `CMakeLists.txt`.

Right now the build fails with:

```
C:/msys64/home/adi/scopehal-apps/lib/scopehal/AcceleratorBuffer.h: In member function 'void AcceleratorBuffer<T>::FreeCpuPointer(T*, MemoryType, size_t)':
C:/msys64/home/adi/scopehal-apps/lib/scopehal/AcceleratorBuffer.h:585:39: error: 'm_tempFileHandle' was not declared in this scope
  585 |                                 close(m_tempFileHandle);
      |                                       ^~~~~~~~~~~~~~~~
```

To be continued...