### PR TITLE
macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(WARNINGS "${WARNINGS} -Wmissing-declarations -Wvla")
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(WARNINGS "${WARNINGS} ")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  set(WARNINGS "${WARNINGS} -Wno-gnu-zero-variadic-macro-arguments")
+  set(WARNINGS "${WARNINGS} -Wno-gnu-zero-variadic-macro-arguments -Wno-unknown-warning-option")
 endif()
 
 set(CMAKE_CXX_FLAGS "-g ${WARNINGS} -mtune=native -ffast-math -fsigned-char")
@@ -28,7 +28,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
 # clang doesn't properly use the attributes and so requires avx to build
 # should get fixed in #475
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+if((NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include(FindOpenMP)
 find_package(glfw3 3.2 REQUIRED)
 
 # Use the local FindVulkan script until we can rely on all users having CMake 3.24 available, at which point we can remove it
+set(Vulkan_FIND_COMPONENTS glslang shaderc_combined)
 include(FindVulkan)
 
 if(NOT Vulkan_FOUND)

--- a/src/ngscopeclient/CMakeLists.txt
+++ b/src/ngscopeclient/CMakeLists.txt
@@ -7,7 +7,8 @@ include_directories(
 	${CMAKE_CURRENT_SOURCE_DIR}/../imgui/misc/cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/../implot/
 	)
-link_directories(${SIGCXX_LIBRARY_DIRS})
+link_directories(${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
+find_package(glfw3 REQUIRED)
 
 ###############################################################################
 #C++ compilation

--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -160,8 +160,15 @@ void VulkanWindow::UpdateFramebuffer()
 {
 	//Get current size of the surface
 	auto caps = g_vkfftPhysicalDevice->getSurfaceCapabilitiesKHR(**m_surface);
-	m_width = caps.maxImageExtent.width;
-	m_height = caps.maxImageExtent.height;
+	glfwGetFramebufferSize(m_window, &m_width, &m_height);
+	if (caps.maxImageExtent.width < m_width) {
+		LogError("Surface not capable of framebuffer width\n");
+		abort();
+	}
+	if (caps.maxImageExtent.height < m_height) {
+		LogError("Surface not capable of framebuffer height\n");
+		abort();
+	}
 
 	float xscale;
 	float yscale;

--- a/src/ngscopeclient/VulkanWindow.cpp
+++ b/src/ngscopeclient/VulkanWindow.cpp
@@ -297,6 +297,8 @@ void VulkanWindow::Render()
 		if (result.first == vk::Result::eErrorOutOfDateKHR || result.first == vk::Result::eSuboptimalKHR)
 		{
 			m_resizeEventPending = true;
+			ImGui::UpdatePlatformWindows();
+			ImGui::RenderPlatformWindowsDefault();
 			Render();
 			return;
 		}

--- a/src/ngscopeclient/ngscopeclient.h
+++ b/src/ngscopeclient/ngscopeclient.h
@@ -31,6 +31,8 @@
 
 #include "../scopehal/scopehal.h"
 
+#define GLFW_INCLUDE_NONE
+#define GLFW_INCLUDE_VULKAN
 #include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <backends/imgui_impl_glfw.h>

--- a/tests/Acceleration/CMakeLists.txt
+++ b/tests/Acceleration/CMakeLists.txt
@@ -7,12 +7,13 @@ add_executable(Acceleration
 catch_discover_tests(Acceleration)
 
 include_directories(${GTKMM_INCLUDE_DIRS} ${SIGCXX_INCLUDE_DIRS})
+target_link_directories(Acceleration PUBLIC ${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 ###############################################################################
 #Linker settings
 target_link_libraries(Acceleration
 	scopehal
 	scopeprotocols
-	yaml-cpp
+	${YAML_LIBRARIES}
 	Catch2::Catch2
 	)

--- a/tests/Filters/CMakeLists.txt
+++ b/tests/Filters/CMakeLists.txt
@@ -13,12 +13,13 @@ add_executable(Filters
 catch_discover_tests(Filters)
 
 include_directories(${GTKMM_INCLUDE_DIRS} ${SIGCXX_INCLUDE_DIRS})
+target_link_directories(Filters PUBLIC ${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 ###############################################################################
 #Linker settings
 target_link_libraries(Filters
 	scopehal
 	scopeprotocols
-	yaml-cpp
+	${YAML_LIBRARIES}
 	Catch2::Catch2
 	)

--- a/tests/Primitives/CMakeLists.txt
+++ b/tests/Primitives/CMakeLists.txt
@@ -10,12 +10,13 @@ add_executable(Primitives
 catch_discover_tests(Primitives)
 
 include_directories(${GTKMM_INCLUDE_DIRS} ${SIGCXX_INCLUDE_DIRS})
+target_link_directories(Primitives PUBLIC ${GTKMM_LIBRARY_DIRS} ${SIGCXX_LIBRARY_DIRS})
 
 ###############################################################################
 #Linker settings
 target_link_libraries(Primitives
 	scopehal
 	scopeprotocols
-	yaml-cpp
+	${YAML_LIBRARIES}
 	Catch2::Catch2
 	)


### PR DESCRIPTION
These changes, along with https://github.com/glscopeclient/scopehal/pull/687 are sufficient to get both `ngscopeclient` launching and running on my M1 Max MacBook Pro using clang-14 from homebrew. Very limited testing has been done so far.
<img width="1392" alt="Screen Shot 2022-09-11 at 5 19 46 PM" src="https://user-images.githubusercontent.com/110989/189552794-bc432bd9-310f-455a-a98d-3681ef225c27.png">

There are some issues with FFTS (as guessed in https://github.com/glscopeclient/scopehal/issues/685#issuecomment-1242894685), but tests are all green when the various instances of `g_gpuFilterEnabled = false` are commented out.