### PR TITLE
PKGBUILD set build type to Release and strip exe/dll for Release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ endif()
 set(CMAKE_CXX_FLAGS "-g ${WARNINGS} -mtune=native -ffast-math -fsigned-char")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# For Release build strip exe/dll
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+
 # clang doesn't properly use the attributes and so requires avx to build
 # should get fixed in #475
 if((NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -26,7 +26,7 @@ makedepends=(
 
 pkgver() {
   cd "${srcdir}"/../..
-  echo '0.0.0.r'"$(git rev-list --count HEAD)"'.g'"$(git describe --all --long | sed 's/^.*-g\(.*\)/\1/')"
+  echo '0.1.0.r'"$(git rev-list --count HEAD)"'.g'"$(git describe --all --long | sed 's/^.*-g\(.*\)/\1/')"
 }
 
 build() {

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -41,7 +41,7 @@ build() {
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "Ninja" \
-    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DBUILD_TESTING=OFF \
     ../

--- a/src/glscopeclient/CMakeLists.txt
+++ b/src/glscopeclient/CMakeLists.txt
@@ -157,6 +157,8 @@ if(WIXPATH AND WIN32)
 				${CMAKE_SOURCE_DIR}/src/glscopeclient/styles ${CMAKE_BINARY_DIR}/dist/windows_x64/styles
 		COMMAND ${CMAKE_COMMAND} -E copy_directory
 				${CMAKE_SOURCE_DIR}/src/glscopeclient/icons ${CMAKE_BINARY_DIR}/dist/windows_x64/icons
+		COMMAND ${CMAKE_COMMAND} -E copy_directory
+				${CMAKE_SOURCE_DIR}/src/glscopeclient/masks ${CMAKE_BINARY_DIR}/dist/windows_x64/masks				
 		COMMAND ${CMAKE_COMMAND} -E copy
 				${CMAKE_SOURCE_DIR}/src/LICENSE
 				${CMAKE_BINARY_DIR}/lib/graphwidget/libgraphwidget.dll
@@ -165,6 +167,7 @@ if(WIXPATH AND WIN32)
 				${CMAKE_BINARY_DIR}/lib/scopeprotocols/libscopeprotocols.dll
 				${CMAKE_BINARY_DIR}/src/glscopeclient/glscopeclient.exe
 				${CMAKE_BINARY_DIR}/dist/windows_x64
+		COMMAND bash -c \"cp -R ${CMAKE_BINARY_DIR}/lib/scopeprotocols/shaders ${CMAKE_BINARY_DIR}/dist/windows_x64\"
 		COMMAND bash -c \"cp -R /mingw64/share/licenses ${CMAKE_BINARY_DIR}/dist/windows_x64\"
 		COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/dist/windows_x64/lib
 		COMMAND bash -c \"cp -R /mingw64/lib/gdk-pixbuf-2.0 ${CMAKE_BINARY_DIR}/dist/windows_x64/lib\"


### PR DESCRIPTION
PKGBUILD set build type to Release
PKGBUILD Update mingw-w64-x86_64-scopehal-apps to v0.1
For Release build strip exe/dll

Build success on my fork
- Stripping exe/dll have improved a lot package at end with up to 10x size improvement
- See https://github.com/bvernoux/scopehal-apps/actions/runs/3072804571

Issue for glscopeclient-windows-portable & glscopeclient-windows.msi
- shaders directory => New shaders are missing (especialy the new one *.spv) 
  - Todo add copy of shaders from scopehal-apps/build/lib/scopeprotocols/shaders
- masks directory is missing
  - Todo add copy of masks from scopehal-apps/src/glscopeclient/masks

Shall be fixed by https://github.com/bvernoux/scopehal-apps/commit/ffd618ae4649ffa1c9b0b9d04681c5da10012aee
