### PR TITLE
macOS GitHub actions CI runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,124 @@
+name: Build-macOS
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
+
+jobs:
+
+  Tarball:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Make Source Tarball
+      run: |
+        cd ..
+        tar -cf source.tar scopehal-apps
+        gzip -S .gz -9 source.tar
+        mv source.tar.gz scopehal-apps/
+
+    - name: Upload Source
+      uses: actions/upload-artifact@v2
+      with:
+        name: glscopeclient-source
+        path: source.tar.gz
+
+  macOS:
+    runs-on: macos-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install Dependencies
+      run: |
+        brew update
+        brew install \
+          ninja \
+          libomp \
+          libsigc++@2 \
+          yaml-cpp \
+          gtkmm3 \
+          glew \
+          glfw
+
+    - name: Clone and Build FFTS Library
+      run: |
+        git clone https://github.com/anthonix/ffts.git /tmp/ffts
+        pushd /tmp/ffts
+        mkdir build
+        cd build
+        cmake \
+          -DENABLE_SHARED=ON \
+          ..
+        make -j4
+        sudo make install
+        popd
+
+    - name: Clone and Build Catch2 Library
+      run: |
+        git clone https://github.com/catchorg/Catch2 /tmp/catch2
+        pushd /tmp/catch2
+        git checkout v2.13.2
+        mkdir build
+        cd build
+        cmake ..
+        make -j 4
+        sudo make install
+        popd
+
+    - name: Install Vulkan SDK
+      uses: humbletim/install-vulkan-sdk@v1.1.1
+      with:
+        version: 1.3.224.1
+        cache: true
+
+    - name: Build
+      run: |
+        export PATH=$(brew --prefix llvm@14)/bin:$PATH
+        export CC=clang
+        export CXX=clang++
+        mkdir build
+        cd build
+        cmake \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_DOCS=OFF \
+          ..
+          ninja
+
+    - name: Run Tests
+      if: ${{ false }} # Temporary disable Run Tests
+      run: |
+        cd build
+        ninja test
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: glscopeclient-macos
+        path: |
+          build/src/glscopeclient/glscopeclient
+          build/src/glscopeclient/gradients/*
+          build/src/glscopeclient/shaders/*
+          build/src/glscopeclient/styles/*
+          build/lib/graphwidget/libgraphwidget.dylib
+          build/lib/scopehal/libscopehal.dylib
+          build/lib/scopeprotocols/libscopeprotocols.dylib
+
+    - name: Upload Documentation
+      if: ${{ false }} # a LaTeX toolchain for macOS takes a while to install, so skip for now
+      uses: actions/upload-artifact@v2
+      with:
+        name: glscopeclient-manual
+        path: build/doc/glscopeclient-manual.pdf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,6 @@ endif()
 set(CMAKE_CXX_FLAGS "-g ${WARNINGS} -mtune=native -ffast-math -fsigned-char")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
-# clang doesn't properly use the attributes and so requires avx to build
-# should get fixed in #475
-if((NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang"))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
-endif()
-
 if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")
 endif(NOT CMAKE_BUILD_TYPE)

--- a/src/glscopeclient/ScopeSyncWizard.cpp
+++ b/src/glscopeclient/ScopeSyncWizard.cpp
@@ -430,7 +430,7 @@ bool ScopeSyncWizard::OnTimer()
 		//If sample rates are equal we can simplify things a lot
 		if(m_primaryWaveform->m_timescale == m_secondaryWaveform->m_timescale)
 		{
-			#ifdef __x86_64__
+			#if defined(__x86_64__) && !defined(__clang__)
 			if(g_hasAvx512F)
 				DoProcessWaveformDensePackedEqualRateAVX512F();
 			else
@@ -441,7 +441,7 @@ bool ScopeSyncWizard::OnTimer()
 		//Also special-case 2:1 sample rate ratio (primary 2x speed of secondary)
 		else if((m_primaryWaveform->m_timescale * 2) == m_secondaryWaveform->m_timescale)
 		{
-			#ifdef __x86_64__
+			#if defined(__x86_64__) && !defined(__clang__)
 			if(g_hasAvx512F)
 				DoProcessWaveformDensePackedDoubleRateAVX512F();
 			else
@@ -627,7 +627,7 @@ void ScopeSyncWizard::DoProcessWaveformDensePackedDoubleRateGeneric()
 	}
 }
 
-#ifdef __x86_64__
+#if defined(__x86_64__) && !defined(__clang__)
 __attribute__((target("avx512f")))
 void ScopeSyncWizard::DoProcessWaveformDensePackedDoubleRateAVX512F()
 {
@@ -706,7 +706,7 @@ void ScopeSyncWizard::DoProcessWaveformDensePackedDoubleRateAVX512F()
 		}
 	}
 }
-#endif /* __x86_64__ */
+#endif /* __x86_64__ && !__clang__*/
 
 void ScopeSyncWizard::DoProcessWaveformDensePackedEqualRateGeneric()
 {
@@ -762,7 +762,7 @@ void ScopeSyncWizard::DoProcessWaveformDensePackedEqualRateGeneric()
 	}
 }
 
-#ifdef __x86_64__
+#if defined(__x86_64__) && !defined(__clang__)
 __attribute__((target("avx512f")))
 void ScopeSyncWizard::DoProcessWaveformDensePackedEqualRateAVX512F()
 {
@@ -830,7 +830,7 @@ void ScopeSyncWizard::DoProcessWaveformDensePackedEqualRateAVX512F()
 		}
 	}
 }
-#endif /* __x86_64__ */
+#endif /* __x86_64__ && !__clang__*/
 
 void ScopeSyncWizard::DoProcessWaveformDensePackedUnequalRate()
 {

--- a/src/glscopeclient/ScopeSyncWizard.h
+++ b/src/glscopeclient/ScopeSyncWizard.h
@@ -130,11 +130,11 @@ protected:
 	bool OnTimer();
 
 	void DoProcessWaveformDensePackedEqualRateGeneric();
-#ifdef __x86_64__
+#if defined(__x86_64__) && !defined(__clang__)
 	void DoProcessWaveformDensePackedEqualRateAVX512F();
 #endif
 	void DoProcessWaveformDensePackedDoubleRateGeneric();
-#ifdef __x86_64__
+#if defined(__x86_64__) && !defined(__clang__)
 	void DoProcessWaveformDensePackedDoubleRateAVX512F();
 #endif
 	void DoProcessWaveformDensePackedUnequalRate();


### PR DESCRIPTION
Along with https://github.com/glscopeclient/scopehal/pull/708, this PR adds a macOS CI build using the github-hosted runners. Won't get us M1/aarch64 coverage, but still a useful reference point.

Example successful run available here: https://github.com/ehntoo/scopehal-apps/actions/runs/3193904104