### PR TITLE
CI: Windows CI runner out of disk space

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -105,33 +105,26 @@ jobs:
         pacman -U --noconfirm msys2/*.zst
         glscopeclient --help
 
+    - name: List files
+      shell: msys2 
+      run: |
+        ls *
+        ls */*
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:
         name: glscopeclient-windows
         path: msys2/*.zst
 
-    - name: Build MSI / portable zip
-      shell: msys2 {0}
-      run: |
-        mkdir build_msi
-        cd build_msi
-        cmake \
-          -G"Ninja" \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DBUILD_TESTING=OFF \
-          -DWIXPATH="/c/Program Files (x86)/WiX Toolset v3.11/bin" \
-          ../
-        cmake --build ./
-
     - name: Upload Artifacts (portable zip)
       uses: actions/upload-artifact@v2
       with:
         name: glscopeclient-windows-portable
-        path: build_msi/dist/windows_x64
+        path: build/dist/windows_x64
 
     - name: Upload Artifacts (MSI)
       uses: actions/upload-artifact@v2
       with:
         name: glscopeclient-windows.msi
-        path: build_msi/dist/*.msi
+        path: build/dist/*.msi

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -106,10 +106,11 @@ jobs:
         glscopeclient --help
 
     - name: List files
-      shell: msys2 
+      shell: msys2 {0}
       run: |
-        ls *
-        ls */*
+        cd .
+        ls ./*
+        ls ./*/*
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -105,13 +105,6 @@ jobs:
         pacman -U --noconfirm msys2/*.zst
         glscopeclient --help
 
-    - name: List files
-      shell: msys2 {0}
-      run: |
-        cd .
-        ls ./*
-        ls ./*/*
-
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -40,6 +40,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "Ninja" \
     -DCMAKE_BUILD_TYPE=Debug \
+    -DWIXPATH="/c/Program Files (x86)/WiX Toolset v3.11/bin"
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DBUILD_TESTING=OFF \
     ../

--- a/msys2/PKGBUILD
+++ b/msys2/PKGBUILD
@@ -40,7 +40,7 @@ build() {
   ${MINGW_PREFIX}/bin/cmake.exe \
     -G "Ninja" \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DWIXPATH="/c/Program Files (x86)/WiX Toolset v3.11/bin"
+    -DWIXPATH="/c/Program Files (x86)/WiX Toolset v3.11/bin" \
     -DCMAKE_INSTALL_PREFIX="${MINGW_PREFIX}" \
     -DBUILD_TESTING=OFF \
     ../


### PR DESCRIPTION
Solved the issue by merging the two individual msi and non_msi builds into one to save disk space. This also optimized the build time quite significantly.