### PR TITLE
Migrate from Gdk::Color to HTML color strings

### DIFF
--- a/src/glscopeclient/CMakeLists.txt
+++ b/src/glscopeclient/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(glscopeclient
 	scopehal
 	scopeprotocols
 	scopeexports
+	graphwidget
 	${GTKMM_LIBRARIES}
 	${SIGCXX_LIBRARIES}
 	${OPENGL_LIBRARY}

--- a/src/glscopeclient/OscilloscopeWindow.cpp
+++ b/src/glscopeclient/OscilloscopeWindow.cpp
@@ -663,37 +663,37 @@ void OscilloscopeWindow::SyncFilterColors()
 {
 	//Filter colors
 	StandardColors::colors[StandardColors::COLOR_DATA] =
-		m_preferences.GetColor("Appearance.Decodes.data_color");
+		m_preferences.GetColor("Appearance.Decodes.data_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_CONTROL] =
-		m_preferences.GetColor("Appearance.Decodes.control_color");
+		m_preferences.GetColor("Appearance.Decodes.control_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_ADDRESS] =
-		m_preferences.GetColor("Appearance.Decodes.address_color");
+		m_preferences.GetColor("Appearance.Decodes.address_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_PREAMBLE] =
-		m_preferences.GetColor("Appearance.Decodes.preamble_color");
+		m_preferences.GetColor("Appearance.Decodes.preamble_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_CHECKSUM_OK] =
-		m_preferences.GetColor("Appearance.Decodes.checksum_ok_color");
+		m_preferences.GetColor("Appearance.Decodes.checksum_ok_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_CHECKSUM_BAD] =
-		m_preferences.GetColor("Appearance.Decodes.checksum_bad_color");
+		m_preferences.GetColor("Appearance.Decodes.checksum_bad_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_ERROR] =
-		m_preferences.GetColor("Appearance.Decodes.error_color");
+		m_preferences.GetColor("Appearance.Decodes.error_color").to_string();
 	StandardColors::colors[StandardColors::COLOR_IDLE] =
-		m_preferences.GetColor("Appearance.Decodes.idle_color");
+		m_preferences.GetColor("Appearance.Decodes.idle_color").to_string();
 
 	//Protocol analyzer colors
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_DEFAULT] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.default_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.default_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_ERROR] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.error_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.error_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_STATUS] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.status_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.status_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_CONTROL] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.control_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.control_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_DATA_READ] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.data_read_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.data_read_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_DATA_WRITE] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.data_write_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.data_write_color").to_string();
 	PacketDecoder::m_backgroundColors[PacketDecoder::PROTO_COLOR_COMMAND] =
-		m_preferences.GetColor("Appearance.Protocol Analyzer.command_color");
+		m_preferences.GetColor("Appearance.Protocol Analyzer.command_color").to_string();
 }
 
 void OscilloscopeWindow::OnPreferenceDialogResponse(int response)

--- a/src/glscopeclient/ProtocolAnalyzerWindow.cpp
+++ b/src/glscopeclient/ProtocolAnalyzerWindow.cpp
@@ -664,8 +664,8 @@ void ProtocolAnalyzerWindow::FillOutRow(
 	stime += tmp;
 
 	//Create the row
-	row[m_columns.m_bgcolor] = p->m_displayBackgroundColor;
-	row[m_columns.m_fgcolor] = p->m_displayForegroundColor;
+	row[m_columns.m_bgcolor] = Gdk::Color(p->m_displayBackgroundColor);
+	row[m_columns.m_fgcolor] = Gdk::Color(p->m_displayForegroundColor);
 	row[m_columns.m_timestamp] = stime;
 	row[m_columns.m_capturekey] = TimePoint(data->m_startTimestamp, data->m_startFemtoseconds);
 	row[m_columns.m_offset] = p->m_offset;

--- a/src/glscopeclient/WaveformArea_cairo.cpp
+++ b/src/glscopeclient/WaveformArea_cairo.cpp
@@ -553,7 +553,7 @@ void WaveformArea::RenderDecodeOverlays(Cairo::RefPtr< Cairo::Context > cr)
 					break;
 
 				double cellwidth = xe - xs;
-				auto color = data->GetColor(i);
+				auto color = Gdk::Color(data->GetColor(i));
 				if(cellwidth < 2)
 				{
 					//This sample is really skinny. There's no text to render so don't waste time with that.
@@ -571,7 +571,7 @@ void WaveformArea::RenderDecodeOverlays(Cairo::RefPtr< Cairo::Context > cr)
 						if(cellxs > xs+2)
 							break;
 
-						auto c = data->GetColor(j);
+						auto c = Gdk::Color(data->GetColor(j));
 						sum_red += c.get_red_p();
 						sum_green += c.get_green_p();
 						sum_blue += c.get_blue_p();

--- a/src/glscopeclient/glscopeclient.h
+++ b/src/glscopeclient/glscopeclient.h
@@ -80,6 +80,7 @@
 
 #include "PreferenceTypes.h"
 
+#include "../graphwidget/Graph.h"
 #include "OscilloscopeWindow.h"
 #include "ScopeApp.h"
 

--- a/src/glscopeclient/glscopeclient.h
+++ b/src/glscopeclient/glscopeclient.h
@@ -52,6 +52,7 @@
 #include "../scopehal/Multimeter.h"
 #include "../scopehal/OscilloscopeChannel.h"
 #include "../scopehal/Filter.h"
+#include "../scopeexports/scopeexports.h"
 
 #include <locale.h>
 

--- a/src/ngscopeclient/Preference.h
+++ b/src/ngscopeclient/Preference.h
@@ -41,6 +41,7 @@
 #include <utility>
 #include <type_traits>
 #include <cstdint>
+#include <set>
 
 #include <imgui.h>
 

--- a/src/ngscopeclient/Preference.h
+++ b/src/ngscopeclient/Preference.h
@@ -42,9 +42,6 @@
 #include <type_traits>
 #include <cstdint>
 
-#include <giomm.h>
-#include <gtkmm.h>
-
 #include <imgui.h>
 
 #include "Unit.h"

--- a/src/ngscopeclient/main.cpp
+++ b/src/ngscopeclient/main.cpp
@@ -35,7 +35,6 @@
 #include "ngscopeclient.h"
 #include "MainWindow.h"
 #include "../scopeprotocols/scopeprotocols.h"
-#include "../scopeexports/scopeexports.h"
 
 using namespace std;
 
@@ -105,7 +104,6 @@ int main(int argc, char* argv[])
 	TransportStaticInit();
 	DriverStaticInit();
 	ScopeProtocolStaticInit();
-	ScopeExportStaticInit();
 	InitializePlugins();
 
 	//Initialize ImGui


### PR DESCRIPTION
These changes accompany https://github.com/glscopeclient/scopehal/pull/710 to refactor our usage of Gdk::Color for specifying colors within scopehal. Additionally, there are a few changes to begin to move towards being able to compile ngscopeclient without GTK.

CI results from my fork, with scopehal pointed at the last commit in https://github.com/glscopeclient/scopehal/pull/710:
Ubuntu: https://github.com/ehntoo/scopehal-apps/actions/runs/3208714570/jobs/5244820709
macOS: https://github.com/ehntoo/scopehal-apps/actions/runs/3208714571/jobs/5244820704
Windows: https://github.com/ehntoo/scopehal-apps/actions/runs/3208714569/jobs/5244820702