### PR TITLE
Fix Windows MSYS2-Mingw64-build / Fix Warnings build-windows.yml & build-ubuntu.yml

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -97,7 +97,7 @@ jobs:
         make test
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: glscopeclient-linux
         path: |
@@ -110,7 +110,7 @@ jobs:
           build/lib/scopeprotocols/libscopeprotocols.so
 
     - name: Upload Documentation
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: glscopeclient-manual
         path: build/doc/glscopeclient-manual.pdf

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,7 +19,7 @@ jobs:
     - run: git config --global core.autocrlf input
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 0
@@ -90,19 +90,19 @@ jobs:
         glscopeclient --help
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: glscopeclient-windows
         path: msys2/*.zst
 
     - name: Upload Artifacts (portable zip)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: glscopeclient-windows-portable
         path: build/dist/windows_x64
 
     - name: Upload Artifacts (MSI)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: glscopeclient-windows.msi
         path: build/dist/*.msi

--- a/src/ngscopeclient/Session.cpp
+++ b/src/ngscopeclient/Session.cpp
@@ -804,7 +804,7 @@ bool Session::LoadMultimeter(int version, const YAML::Node& node, bool online, I
 
 	//Make any config settings to the instrument from our preference settings, then add it and we're good to go
 	//ApplyPreferences(meter);
-	table.emplace(node["id"].as<int>(), meter);
+	table.emplace(node["meterid"].as<int>(), meter);
 	meter->LoadConfiguration(version, node, table);
 	AddMultimeter(meter, false);
 
@@ -890,7 +890,10 @@ YAML::Node Session::SerializeInstrumentConfiguration(IDTable& table)
 			config["type"] = "oscilloscope";
 		}
 		else if(meter)
+		{
 			config["type"] = "multimeter";
+			config["id"] = config["meterid"].as<int>();
+		}
 
 		node["inst" + config["id"].as<string>()] = config;
 	}


### PR DESCRIPTION
Fix build error for Windows MSYS2-Mingw64
Fix warnings on build-windows.yml & build-ubuntu.yml:
- Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2