### PR TITLE
Fix MinGW64 build failure with gslang

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,7 +54,7 @@ jobs:
         git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
         cd ../..
         ./update_glslang_sources.py
-        git apply msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
+        git apply ${{ github.workspace }}/msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
         
         SOURCE_DIR=~/glslang
         BUILD_DIR=$SOURCE_DIR/build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,6 +54,7 @@ jobs:
         git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
         cd ../..
         ./update_glslang_sources.py
+        git apply msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
         
         SOURCE_DIR=~/glslang
         BUILD_DIR=$SOURCE_DIR/build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,7 +54,7 @@ jobs:
         git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
         cd ../..
         ./update_glslang_sources.py
-        git apply ${{ github.workspace }}/msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
+        git apply "${{ github.workspace }}/msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch"
         
         SOURCE_DIR=~/glslang
         BUILD_DIR=$SOURCE_DIR/build

--- a/msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
+++ b/msys2/gslang_MachineIndependent_SymbolTable_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git "a/glslang/MachineIndependent/SymbolTable.h" "b/glslang/MachineIndependent/SymbolTable.h"
+index 2e570bb3..a165dac0 100644
+--- "a/glslang/MachineIndependent/SymbolTable.h"
++++ "b/glslang/MachineIndependent/SymbolTable.h"
+@@ -68,6 +68,7 @@
+ #include "../Include/Common.h"
+ #include "../Include/intermediate.h"
+ #include "../Include/InfoSink.h"
++#include <cstdint>
+ 
+ namespace glslang {
+ 


### PR DESCRIPTION
Before to merge this fix merge and use https://github.com/glscopeclient/scopehal-docs/pull/64