### PR TITLE
Update GitHub CI build-ubuntu.yml & build-windows.yml to use VulkanSDK 1.3.250.0

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -65,9 +65,9 @@ jobs:
         pushd ~
         mkdir vulkan
         cd vulkan
-        wget https://sdk.lunarg.com/sdk/download/1.3.224.1/linux/vulkansdk-linux-x86_64-1.3.224.1.tar.gz
-        tar xf vulkansdk-linux-x86_64-1.3.224.1.tar.gz
-        export VULKAN_SDK=~/vulkan/1.3.224.1/x86_64
+        wget https://sdk.lunarg.com/sdk/download/1.3.250.0/linux/vulkansdk-linux-x86_64-1.3.250.0.tar.gz
+        tar xf vulkansdk-linux-x86_64-1.3.250.0.tar.gz
+        export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
         sudo cp -r $VULKAN_SDK/include/vulkan/ /usr/local/include/
         sudo cp -P $VULKAN_SDK/lib/libvulkan.so* /usr/local/lib/
         sudo cp $VULKAN_SDK/lib/libVkLayer_*.so /usr/local/lib/
@@ -78,7 +78,7 @@ jobs:
 
     - name: Build
       run: |
-        export VULKAN_SDK=~/vulkan/1.3.224.1/x86_64
+        export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
         export PATH=$VULKAN_SDK/bin:$PATH
         export LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
         export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/explicit_layer.d

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  VULKAN_SDK_VERSION: 1.3.250.0
+
 jobs:
 
   Linux:
@@ -65,9 +68,9 @@ jobs:
         pushd ~
         mkdir vulkan
         cd vulkan
-        wget https://sdk.lunarg.com/sdk/download/1.3.250.0/linux/vulkansdk-linux-x86_64-1.3.250.0.tar.gz
-        tar xf vulkansdk-linux-x86_64-1.3.250.0.tar.gz
-        export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
+        wget https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_SDK_VERSION }}/linux/vulkansdk-linux-x86_64-${{ env.VULKAN_SDK_VERSION }}.tar.gz
+        tar xf vulkansdk-linux-x86_64-${{ env.VULKAN_SDK_VERSION }}.tar.gz
+        export VULKAN_SDK=~/vulkan/${{ env.VULKAN_SDK_VERSION }}/x86_64
         sudo cp -r $VULKAN_SDK/include/vulkan/ /usr/local/include/
         sudo cp -P $VULKAN_SDK/lib/libvulkan.so* /usr/local/lib/
         sudo cp $VULKAN_SDK/lib/libVkLayer_*.so /usr/local/lib/
@@ -78,7 +81,7 @@ jobs:
 
     - name: Build
       run: |
-        export VULKAN_SDK=~/vulkan/1.3.250.0/x86_64
+        export VULKAN_SDK=~/vulkan/${{ env.VULKAN_SDK_VERSION }}/x86_64
         export PATH=$VULKAN_SDK/bin:$PATH
         export LD_LIBRARY_PATH=$VULKAN_SDK/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
         export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/explicit_layer.d

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -39,16 +39,16 @@ jobs:
       uses: actions/cache@v3
       with:
         path: D:/a/_temp/msys64/home/runneradmin/glslang
-        key: ${{ runner.os }}-glslang-1.3.224.1
+        key: ${{ runner.os }}-glslang-1.3.250.0
 
-    - name: Build glslang tags/sdk-1.3.224.1
+    - name: Build glslang tags/sdk-1.3.250.0
       if: steps.cache-glslang.outputs.cache-hit != 'true'
       run: |
-        # Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.224.1 for Windows and built with Visual Studio 2017)
+        # Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.250.0 for Windows and built with Visual Studio 2019)
         cd ~
         git clone https://github.com/KhronosGroup/glslang.git
         cd glslang
-        git checkout tags/sdk-1.3.224.1
+        git checkout tags/sdk-1.3.250.0
         git clone https://github.com/google/googletest.git External/googletest
         cd External/googletest
         git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
@@ -64,18 +64,18 @@ jobs:
 
     - name: Install Vulkan SDK
       run: |
-        wget https://sdk.lunarg.com/sdk/download/1.3.224.1/windows/VulkanSDK-1.3.224.1-Installer.exe
-        ./VulkanSDK-1.3.224.1-Installer.exe --accept-licenses --default-answer --confirm-command install
-        echo "/c/VulkanSDK/1.3.224.1/Bin" >> $GITHUB_PATH
-        rm -f VulkanSDK-1.3.224.1-Installer.exe
+        wget https://sdk.lunarg.com/sdk/download/1.3.250.0/windows/VulkanSDK-1.3.250.0-Installer.exe
+        ./VulkanSDK-1.3.250.0-Installer.exe --accept-licenses --default-answer --confirm-command install
+        echo "/c/VulkanSDK/1.3.250.0/Bin" >> $GITHUB_PATH
+        rm -f VulkanSDK-1.3.250.0-Installer.exe
 
     - name: Setup Paths and Env for all steps
       run: |
         rm -f ~/.bash_profile
         
-        echo "PATH=/c/VulkanSDK/1.3.224.1/Bin:\$PATH" >> ~/.bash_profile
-        echo "export VK_SDK_PATH=/c/VulkanSDK/1.3.224.1" >> ~/.bash_profile
-        echo "export VULKAN_SDK=/c/VulkanSDK/1.3.224.1" >> ~/.bash_profile
+        echo "PATH=/c/VulkanSDK/1.3.250.0/Bin:\$PATH" >> ~/.bash_profile
+        echo "export VK_SDK_PATH=/c/VulkanSDK/1.3.250.0" >> ~/.bash_profile
+        echo "export VULKAN_SDK=/c/VulkanSDK/1.3.250.0" >> ~/.bash_profile
         echo "export GLSLANG_BUILD_PATH=~/glslang/build/install" >> ~/.bash_profile
 
     - name: Build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  VULKAN_SDK_VERSION: 1.3.250.0
+
 jobs:
 
   Windows:
@@ -39,16 +42,16 @@ jobs:
       uses: actions/cache@v3
       with:
         path: D:/a/_temp/msys64/home/runneradmin/glslang
-        key: ${{ runner.os }}-glslang-1.3.250.0
+        key: ${{ runner.os }}-glslang-${{ env.VULKAN_SDK_VERSION }}
 
-    - name: Build glslang tags/sdk-1.3.250.0
+    - name: Build glslang tags/sdk-${{ env.VULKAN_SDK_VERSION }}
       if: steps.cache-glslang.outputs.cache-hit != 'true'
       run: |
-        # Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK-1.3.250.0 for Windows and built with Visual Studio 2019)
+        # Windows mingw64 glslang build (as it is not fully integrated in VulkanSDK for Windows)
         cd ~
         git clone https://github.com/KhronosGroup/glslang.git
         cd glslang
-        git checkout tags/sdk-1.3.250.0
+        git checkout tags/sdk-${{ env.VULKAN_SDK_VERSION }}
         git clone https://github.com/google/googletest.git External/googletest
         cd External/googletest
         git checkout 0c400f67fcf305869c5fb113dd296eca266c9725
@@ -64,18 +67,18 @@ jobs:
 
     - name: Install Vulkan SDK
       run: |
-        wget https://sdk.lunarg.com/sdk/download/1.3.250.0/windows/VulkanSDK-1.3.250.0-Installer.exe
-        ./VulkanSDK-1.3.250.0-Installer.exe --accept-licenses --default-answer --confirm-command install
-        echo "/c/VulkanSDK/1.3.250.0/Bin" >> $GITHUB_PATH
-        rm -f VulkanSDK-1.3.250.0-Installer.exe
+        wget https://sdk.lunarg.com/sdk/download/${{ env.VULKAN_SDK_VERSION }}/windows/VulkanSDK-${{ env.VULKAN_SDK_VERSION }}-Installer.exe
+        ./VulkanSDK-${{ env.VULKAN_SDK_VERSION }}-Installer.exe --accept-licenses --default-answer --confirm-command install
+        echo "/c/VulkanSDK/${{ env.VULKAN_SDK_VERSION }}/Bin" >> $GITHUB_PATH
+        rm -f VulkanSDK-${{ env.VULKAN_SDK_VERSION }}-Installer.exe
 
     - name: Setup Paths and Env for all steps
       run: |
         rm -f ~/.bash_profile
         
-        echo "PATH=/c/VulkanSDK/1.3.250.0/Bin:\$PATH" >> ~/.bash_profile
-        echo "export VK_SDK_PATH=/c/VulkanSDK/1.3.250.0" >> ~/.bash_profile
-        echo "export VULKAN_SDK=/c/VulkanSDK/1.3.250.0" >> ~/.bash_profile
+        echo "PATH=/c/VulkanSDK/${{ env.VULKAN_SDK_VERSION }}/Bin:\$PATH" >> ~/.bash_profile
+        echo "export VK_SDK_PATH=/c/VulkanSDK/${{ env.VULKAN_SDK_VERSION }}" >> ~/.bash_profile
+        echo "export VULKAN_SDK=/c/VulkanSDK/${{ env.VULKAN_SDK_VERSION }}" >> ~/.bash_profile
         echo "export GLSLANG_BUILD_PATH=~/glslang/build/install" >> ~/.bash_profile
 
     - name: Build


### PR DESCRIPTION
Update GitHub CI build-ubuntu.yml & build-windows.yml to use VulkanSDK 1.3.250.0
Do not forget to also merge & update https://github.com/glscopeclient/scopehal-docs/pull/65