### PR TITLE
Add missing make4ht and dvipng utils to ubuntu CI

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -33,6 +33,8 @@ jobs:
           liblxi-dev \
           texlive \
           texlive-fonts-extra \
+          texlive-extra-utils \
+          dvipng \
           libglew-dev \
           libvulkan-dev \
           glslang-dev \


### PR DESCRIPTION
Needed for latex->html conversion.